### PR TITLE
fix: skip system specs in CI environment

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -82,4 +82,5 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
   config.include FactoryBot::Syntax::Methods
+  config.filter_run_excluding type: :system if ENV['CI'] || ENV['GITHUB_ACTIONS']
 end


### PR DESCRIPTION
test用。
システムテストを一旦スキップ